### PR TITLE
Fix initial setup of units from env var

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -20,7 +20,7 @@ services:
       - dbus:/run/dbus
     environment:
       DBUS_SYSTEM_BUS_ADDRESS: unix:path=/run/dbus/system_bus_socket
-      MOCK_SYSTEMD_UNITS: 'balena.service'
+      MOCK_SYSTEMD_UNITS: balena.service
 
   dbus:
       image: balenablocks/dbus


### PR DESCRIPTION
Initial units were previously setup in the start.sh script but this would create a race where units could not be created fast enough before the tests in the sut container ran. This moves the unit creation to main.rs so the units can be made available as soon as the server is setup.

Change-type: patch